### PR TITLE
add adafruit i2s amp breakout to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This version of MiniSynth Pi can be built, so that it can be used with an extern
 * [pHAT DAC](https://shop.pimoroni.com/products/phat-dac) (with PCM5102A DAC)
 * PiFi DAC+ v2.0 (with PCM5122 DAC)
 * [Adafruit I2S Audio Bonnet](https://www.adafruit.com/product/4037) (with UDA1334A DAC)
+* [Adafruit I2S 3W Class D Amplifier Breakout](https://www.adafruit.com/product/3006) (with MAX98357A DAC)
 
 Other I2S interfaces with these DACs may be compatible too. The I2C slave address of the PCM5122 DAC is auto-probed (0x4C or 0x4D).
 


### PR DESCRIPTION
I am working on an all-in-one portable synth/keyboard so I tested minisynth with a little I2S amplifier breakout board that I had and it worked great.